### PR TITLE
avoid a custom Setup.hs to ease building on newer GHCs/cabals

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,6 +1,2 @@
 import Distribution.Simple
-import System.Cmd(system)
-
-main = defaultMainWithHooks $ simpleUserHooks { runTests = runElfTests }
-
-runElfTests a b pd lb = system "runhaskell -i./src ./tests/Test.hs" >> return ()
+main = defaultMain

--- a/string-qq.cabal
+++ b/string-qq.cabal
@@ -1,5 +1,5 @@
 Name:          string-qq
-Version:       0.0.2
+Version:       0.0.3
 License:       PublicDomain
 License-file:  LICENSE
 Category:      Data
@@ -7,13 +7,11 @@ Author:        Audrey Tang
 Copyright:     Audrey Tang
 Maintainer:    Audrey Tang <audreyt@audreyt.org>
 Stability:     unstable
-Cabal-Version: >= 1.6
-Build-Depends: base
-Build-Type:    Custom
+Cabal-Version: >= 1.8
+Build-Type:    Simple
 Synopsis:      QuasiQuoter for non-interpolated strings, texts and bytestrings.
 Description:   QuasiQuoter for non-interpolated strings, texts and bytestrings.
-Data-Files:    tests/Test.hs
-Tested-With:   GHC==6.10.1, GHC==7.0.2
+Tested-With:   GHC==6.10.1, GHC==7.0.2, GHC==8.2.2
 
 Source-Repository head
     type: git
@@ -24,3 +22,9 @@ library
     build-depends:   base > 3 && < 6, template-haskell >= 2
     hs-source-dirs:  src
     exposed-modules: Data.String.QQ
+
+test-suite string-qq-test
+    type:           exitcode-stdio-1.0
+    hs-source-dirs: tests
+    main-is:        Test.hs
+    build-depends:  base > 3 && < 6, string-qq, HUnit >=1.6 && <1.7, text >=1.2 && <1.3


### PR DESCRIPTION
string-qq doesn't build with recent Cabal/GHC combos. Below is a quick IRC log with some explanation:

```
[15:34] <dmwit> What is cabal trying to tell me here?
[15:34] <dmwit> http://lpaste.net/363332
[15:36] <dmwit> (This is the latest cabal from git as of one or two days ago, in case it matters.)
[15:43] <dmwit> Wow. I get a basically identical error from a fresh directory by running `echo 'name: test\nversion: 0' >test.cabal && cabal new-build`.
[15:43] <hvr> dmwit: it says that string-qq needs its custom setup-depends fixed up
[15:44] <dmwit> That was a bit too dense for me. Can you unpack that a little bit?
[15:44] <hvr> dmwit: sure :-)
[15:45] <hvr> dmwit: so cabal infers that we need at least lib:Cabal > 2 for a custom setup script
[15:45] <hvr> however, string-qq conflicts with that
[15:45] <hvr> because it lacks a custom setup section
[15:46] <hvr> and thus implicit bounds on `Cabal` are inferred
[15:46] <hvr> anyway, lemme see if we can fix this up
[15:47] <dmwit> Why do we need lib:Cabal > 2 for a custom setup script? Those have been around for ages.
[15:47] <hvr> dmwit: you need Cabal >= 2 for GHC 8.2
[15:48] <hvr> because older Cabal versions don't know how to interact w/ GHC 8.2 properly
[15:48] <hvr> the lower bound is a function of your GHC version
```

One fix was implemented as a revision on Hackage; but this fix is cleaner in the sense that it should be more forward-compatible. I've removed the custom `Setup.hs` that existed only to allow running the test suite and moved it to a `test-suite` stanza.