### PR TITLE
Add support for ghc9.4.3

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,39 @@
+name: github-action
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        ghc: ['8.6.5', '9.4.3']
+        os: ['ubuntu-latest', 'macos-latest']
+    runs-on: ${{ matrix.os }}
+
+    name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: haskell/actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+    - name: Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ matrix.ghc }}-build-
+          ${{ runner.os }}-${{ matrix.ghc }}-
+          ${{ runner.os }}
+
+    - name: Install dependencies
+      run: cabal build --only-dependencies --enable-tests --enable-benchmarks
+    - name: Build
+      run: cabal build --enable-tests --enable-benchmarks all
+    - name: Run tests
+      run: cabal test --enable-tests all
+    - name: Build Docs
+      run: cabal haddock

--- a/string-qq.cabal
+++ b/string-qq.cabal
@@ -11,7 +11,7 @@ Cabal-Version: >= 1.8
 Build-Type:    Simple
 Synopsis:      QuasiQuoter for non-interpolated strings, texts and bytestrings.
 Description:   QuasiQuoter for non-interpolated strings, texts and bytestrings, useful for writing multi-line IsString literals.
-Tested-With:   GHC==6.10.1, GHC==7.0.2, GHC==8.2.2, GHC==8.6.5
+Tested-With:   GHC==6.10.1, GHC==7.0.2, GHC==8.2.2, GHC==8.6.5, GHC==9.4.3
 
 Source-Repository head
     type: git
@@ -27,4 +27,4 @@ test-suite string-qq-test
     type:           exitcode-stdio-1.0
     hs-source-dirs: tests
     main-is:        Test.hs
-    build-depends:  base > 3 && < 6, string-qq, HUnit >=1.6 && <1.7, text >=1.2 && <1.3
+    build-depends:  base > 3 && < 6, string-qq, HUnit >=1.6 && <1.7, text >=1.2 && <2.1


### PR DESCRIPTION
I also added a github action that tests ghc 8.6.5 and ghc 9.4.3. I'm not sure ghc 6 or 7 can be tested this way, though, due to their age.